### PR TITLE
Fix Nginx server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.vscode
+build
+.prettierrc
+.eslintrc
+.eslintignore
+.gitignore
+.npmignore
+
+node_modules

--- a/dockerfile
+++ b/dockerfile
@@ -2,12 +2,13 @@
 FROM node:14-alpine as build-deps
 WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
-RUN yarn
+RUN yarn --frozen-lockfile 
 COPY . ./
 RUN yarn build
 
 # Stage 2 - the production environment
-FROM nginx:1.12-alpine
-COPY --from=build-deps /usr/src/app/build /usr/share/nginx/html
+FROM nginx:1.15.2-alpine
+COPY --from=build-deps /usr/src/app/build /var/www
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,62 @@
+
+# auto detects a good number of processes to run
+worker_processes auto;
+
+#Provides the configuration file context in which the directives that affect connection processing are specified.
+events {
+  # Sets the maximum number of simultaneous connections that can be opened by a worker process.
+  worker_connections 8000;
+  # Tells the worker to accept multiple connections at a time
+  multi_accept on;
+}
+
+
+http {
+  # what times to include
+  include /etc/nginx/mime.types;
+  # what is the default one
+  default_type application/octet-stream;
+
+  # Sets the path, format, and configuration for a buffered log write
+  log_format compression '$remote_addr - $remote_user [$time_local] '
+  '"$request" $status $upstream_addr '
+  '"$http_referer" "$http_user_agent"';
+
+  server {
+    # listen on port 80
+    listen 80;
+    # save logs here
+    access_log /var/log/nginx/access.log compression;
+
+    # where the root here
+    root /var/www;
+    # what file to server as index
+    index index.html index.htm;
+
+    location / {
+      # First attempt to serve request as file, then
+      # as directory, then fall back to redirecting to index.html
+      try_files $uri $uri/ /index.html;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+      expires 1M;
+      access_log off;
+      add_header Cache-Control "public";
+    }
+
+    # Javascript and CSS files
+    location ~* \.(?:css|js)$ {
+      try_files $uri =404;
+      expires 1y;
+      access_log off;
+      add_header Cache-Control "public";
+    }
+
+    # Any route containing a file extension (e.g. /devicesfile.js)
+    location ~ ^.+\..+$ {
+      try_files $uri =404;
+    }
+  }
+}


### PR DESCRIPTION
Since the old one didn't have config yet. If we try to enter `localhost:3000/privacy` the nginx will return `404` because Nginx didn't know what the route should proxy to

To reproduce the problem 
1. `docker build -t test-lg .`
2. `docker run -d -p 3001:80 test-lg`
3. The server should available on [localhost:3001](http://localhost:3001)
4. Enter [localhost:3001](http://localhost:3001) should work fine
5. Enter [localhost:3001/privacy](http://localhost:3001/privacy) will return 404

This PR solved the problem 